### PR TITLE
Add Marketing for Engineers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ A comprehensive collection of the best iOS articles and blogs.
 - https://github.com/sanketfirodiya/awesome-ios-plugins
 - https://github.com/sanketfirodiya/sample-watchkit-apps
 - https://github.com/sanketfirodiya/ios-marketing-resources
+- https://github.com/LisaDziuba/Marketing-for-Engineers
 
 
 ## Contact


### PR DESCRIPTION
It's cool marketing articles for iOS & macOS engineers, which we collected while making our startup.